### PR TITLE
PatientReferenceTransformer: Properly merge filter values

### DIFF
--- a/src/Model/Transformer/PatientReferenceTransformer.php
+++ b/src/Model/Transformer/PatientReferenceTransformer.php
@@ -87,14 +87,14 @@ class PatientReferenceTransformer extends ModelTransformerAbstract
             $value = explode('@', str_replace(['Patient/', $patientFormatter->getPatientEndpoint()], '', $patient));
 
             if (count($value) === 2) {
-                $patientSearchParts[] = [
+                $patientSearchParts = [
                     'gr2o_patient_nr' => $value[0],
                     'gr2o_id_organization' => $value[1],
                 ];
             }
         }
         if (count($patientSearchParts)) {
-            $filter[] = $patientSearchParts;
+            $filter = array_merge($filter, $patientSearchParts);
         }
 
         unset($filter[$patientField]);


### PR DESCRIPTION
With this as filter input:

    array (size=2)
      'patient' => string '100025@70' (length=9)
      'gr2o_id_organization' =>
        array (size=5)
          0 => int 70
          1 => int 71
          2 => int 72
          3 => int 73
          4 => int 74

This changes the result of the transformPatientFilter() function from:

    array (size=2)
      'gr2o_id_organization' =>
        array (size=5)
          0 => int 70
          1 => int 71
          2 => int 72
          3 => int 73
          4 => int 74
      0 =>
        array (size=1)
          0 =>
            array (size=2)
              'gr2o_patient_nr' => string '100025' (length=6)
              'gr2o_id_organization' => string '70' (length=2)

to:

    array (size=2)
      'gr2o_id_organization' => string '70' (length=2)
      'gr2o_patient_nr' => string '100025' (length=6)